### PR TITLE
Roi/fix readme redis image

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ Run Firebase auth emulator:
 firebase emulators:start --only auth
 ```
 
-Run redis-stack docker container locally:
+Run redis-stack-server docker container locally:
 ```
-docker run -p 6379:6379 redis/redis-stack:latest
+docker run -p 6379:6379 redis/redis-stack-server:latest
 ```
 
 ### Generating open api typescript client


### PR DESCRIPTION
When running locally, there is a problem with redis-stack image with ReJSON module.
using redis-stack-server image fixes the issue